### PR TITLE
Special subdomain option locally generate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ tunnel:
 ```
 
 In fact tcp-mode is a special case. If `proto` is specified, the `tcp://` prefix is replaced with `http://` for the Zuul tests to run.
+
+Sometimes `ngrok` recycles subdomains which can lead to some restarts when running tests on multiple browsers. To be more sure that this doesn't happen you can specify a special `subdomain` tunnel option to force a long generated subdomain:
+
+```
+tunnel:
+  type: ngrok
+  authtoken: JnawIksKFkXQzrxSjIjQ
+  subdomain: @unique
+```
+
+To specify this option (or any subdomain of your choosing) you need to specify the `authtoken` option as well.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var ngrok = require('ngrok');
 var extend = require('extend');
+var rand_id = require('./lib/random-id');
 
 function Tunnel(config) {
   if (!this instanceof Tunnel) {
@@ -9,10 +10,16 @@ function Tunnel(config) {
   var self = this;
 
   self.tunnel_settings = config.tunnel;
+
+  self.auto_uniq_subdomain = self.tunnel_settings.subdomain === '@unique';
 }
 
 Tunnel.prototype.connect = function(port, cb) {
   var self = this;
+
+  if (self.auto_uniq_subdomain) {
+    self.tunnel_settings.subdomain = rand_id();
+  }
 
   ngrok.connect(extend({ port: port }, self.tunnel_settings), function(err, url) {
     if (err) {

--- a/lib/random-id.js
+++ b/lib/random-id.js
@@ -1,0 +1,12 @@
+// Using the same subdomain generation scheme as `localtunnel-server` (https://github.com/defunctzombie/localtunnel-server)
+var chars = 'abcdefghijklmnopqrstuvwxyz';
+
+module.exports = function() {
+  var randomstring = '';
+  for (var i=0; i<10; ++i) {
+    var rnum = Math.floor(Math.random() * chars.length);
+    randomstring += chars[rnum];
+  }
+
+  return randomstring;
+};


### PR DESCRIPTION
Subdomain can be forced to a long generated name to avoid recycling (that ngrok might do) by specifying a special subdomain value:

```
subdomain: @unique
```
