### PR TITLE
Fix issue with ngrok lib setting authtoken

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,12 @@ function Tunnel(config) {
   var self = this;
 
   self.tunnel_settings = config.tunnel;
-  if (AUTH_TOKEN) {
-    self.tunnel_settings = AUTH_TOKEN;
-  }
 }
 
 Tunnel.prototype.connect = function(port, cb) {
   var self = this;
 
+  if (AUTH_TOKEN) ngrok.authtoken(AUTH_TOKEN);
   ngrok.connect(extend({ port: port }, self.tunnel_settings), function(err, url) {
     if (err) {
       err.stack = '';


### PR DESCRIPTION
`ngrok` has a bug were it requires the authtoken to be set before calling the API. This fixes that issue calling the set explicitly before the call to connect.
