### PR TITLE
Upgrade ngrok dependency to 2.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ngrok"
   ],
   "dependencies": {
-    "ngrok": "0.2.2",
+    "ngrok": "2.1.6",
     "extend": "2.0.0"
   },
   "author": "Tony Kovanen <tonykovanen@hotmail.com>",


### PR DESCRIPTION
With the current version we have an issue with custom subdomains described in inconshreveable/ngrok#248.
