### PR TITLE
Use xtend instead of extend

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var ngrok = require('ngrok');
-var extend = require('extend');
+var xtend = require('xtend');
 
 var AUTH_TOKEN = process.env.NGROK_AUTH_TOKEN;
 
@@ -19,7 +19,7 @@ function Tunnel(config) {
 Tunnel.prototype.connect = function(port, cb) {
   var self = this;
 
-  ngrok.connect(extend({ port: port }, self.tunnel_settings), function(err, url) {
+  ngrok.connect(xtend({ port: port }, self.tunnel_settings), function(err, url) {
     if (err) {
       err.stack = '';
       cb(err);

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "ngrok"
   ],
   "dependencies": {
-    "ngrok": "2.1.6",
-    "extend": "2.0.0"
+    "ngrok": "2.1.8",
+    "xtend": "4.0.1"
   },
   "author": "Tony Kovanen <tonykovanen@hotmail.com>",
   "license": "MIT"


### PR DESCRIPTION
`extend` is used without the deep option here, so it is safe to switch to `xtend` which is smaller and faster.
This also updates `ngrok` to its latest version (2.1.8).
