### PR TITLE
Update ngrok to latest in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ngrok"
   ],
   "dependencies": {
-    "ngrok": "2.1.8",
+    "ngrok": "^2.1.8",
     "xtend": "4.0.1"
   },
   "author": "Tony Kovanen <tonykovanen@hotmail.com>",


### PR DESCRIPTION
It's up to 2.2.3 now. I found that the current (2.1.8) was throwing errors for me when I tried to use zuul-ngrok (in particular "the tunnel http://mydomain.ngrok.io is already bound to another tunnel session")