### PR TITLE
Updated ngrok version to run in arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ngrok"
   ],
   "dependencies": {
-    "ngrok": "2.1.8",
+    "ngrok": "3.1.0",
     "xtend": "4.0.1"
   },
   "author": "Tony Kovanen <tonykovanen@hotmail.com>",


### PR DESCRIPTION
Updated ngrok version to 3.1.0 as package was not getting installed in arm64 platform. Please find below error which i was getting before this update:
> ngrok@2.1.8 postinstall /zuul-ngrok/node_modules/ngrok
> node ./postinstall.js

ngrok - platform linuxarm64 is not supported.

Once updated it got resolved.
Please update it as we can work on with zuul-ngrok in arm64 platform.
Thanks in advance.